### PR TITLE
Add modelled_policies.yaml

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - modelled_policies.yaml with content for modal dialog.

--- a/policyengine_canada/modelled_policies.yaml
+++ b/policyengine_canada/modelled_policies.yaml
@@ -1,0 +1,78 @@
+core:
+  modelled:
+    - Federal income tax (except Quebec)
+    - Benefits (CCB, CDB, CWB, dental, OAS)
+    - Tax credits (age amount, GST, DTC, CAIP, etc.)
+  not_modelled:
+    - Guaranteed Income Supplement and Spousal Allowance
+filtered:
+  province_name:
+    AB:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    BC:
+      modelled:
+        - Income tax
+        - Some tax credits (age, tax reduction, BCCATC)
+        - BC family benefit
+      not_modelled:
+        - [fill in]
+    MB:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    NB:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    NL:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    NS:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    NT:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    NU:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    ONT:
+      modelled:
+        - Income tax
+        - Tax credits (LIFT, NOEC, OEPTC, OSTC)
+        - Benefits (OCB, Trillium)
+        - Senior homeowners property tax grant
+      not_modelled:
+        - [fill in]
+    PE:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    QC:
+      not_modelled:
+        - Income tax
+        - Benefits
+    SK:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions
+    YT:
+      modelled:
+        - Income tax brackets
+      not_modelled:
+        - Benefits, tax credits, and deductions


### PR DESCRIPTION
Fixes #173

@pavelmakarchuk and @alex-rand could you please take a look? This text will populate modal dialogs that users see before we show net income, depending on their province.

In particular, I left not_modelled blank for BC and ON

@nikhilwoodruff anything else we need to do to make the modal work?