### PR TITLE
Add Ontario Health Premium

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Ontario health premium.

--- a/policyengine_canada/parameters/gov/provinces/on/tax/health_premium/rate.yaml
+++ b/policyengine_canada/parameters/gov/provinces/on/tax/health_premium/rate.yaml
@@ -1,0 +1,55 @@
+description: Ontario health premium rate 
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-CAD
+  rate_unit: /1
+  name: ontario_health_premium_rate
+  label: Ontario health premium rates
+  reference:
+    - title: Taxation Act, 2007
+      href: https://www.ontario.ca/laws/statute/07t11#BK8
+brackets:
+  - threshold:
+      2022-01-01: 0
+    rate:
+      2022-01-01: 0
+  - threshold:
+      2022-01-01: 20_000
+    rate:
+      2022-01-01: 0.06
+  - threshold:
+      2022-01-01: 25_000
+    rate:
+      2022-01-01: 0
+  - threshold:
+      2022-01-01: 36_000
+    rate:
+      2022-01-01: 0.06
+  - threshold:
+      2022-01-01: 38_500
+    rate:
+      2022-01-01: 0
+  - threshold:
+      2022-01-01: 48_000
+    rate:
+      2022-01-01: 0.25
+  - threshold:
+      2022-01-01: 48_600
+    rate:
+      2022-01-01: 0
+  - threshold:
+      2022-01-01: 72_000
+    rate:
+      2022-01-01: 0.25
+  - threshold:
+      2022-01-01: 72_600
+    rate:
+      2022-01-01: 0
+  - threshold:
+      2022-01-01: 200_000
+    rate:
+      2022-01-01: 0.25
+  - threshold:
+      2022-01-01: 200_600
+    rate:
+      2022-01-01: 0

--- a/policyengine_canada/tests/gov/provinces/on/tax/health_premium/health_premium.yaml
+++ b/policyengine_canada/tests/gov/provinces/on/tax/health_premium/health_premium.yaml
@@ -1,0 +1,63 @@
+- name: Ontario health premium; below first bracket 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 12_345
+  output:
+    on_health_premium: 0
+
+- name: Ontario health premium; at first bracket 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 20_000
+  output:
+    on_health_premium: 0
+
+- name: Ontario health premium; middle bracket 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 50_000
+  output:
+    on_health_premium: 600
+
+- name: Ontario health premium; between lower brackets 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 22_222
+  output:
+    on_health_premium: 133.32
+
+- name: Ontario health premium; between upper brackets 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 200_123
+  output:
+    on_health_premium: 780.75
+
+- name: Ontario health premium; at maximum amount 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 200_600
+  output:
+    on_health_premium: 900
+
+- name: Ontario health premium; past maximum amount 
+  period: 2022
+  input:
+    province_code: ONT
+    on_taxable_income: 10_000_000_000
+  output:
+    on_health_premium: 900
+
+- name: Ontario health premium; wrong province
+  period: 2022
+  input:
+    province_code: AB
+    on_taxable_income: 45_678
+  output:
+    on_health_premium: 0

--- a/policyengine_canada/variables/gov/provinces/on/tax/health_premium/on_health_premium.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/health_premium/on_health_premium.py
@@ -1,0 +1,17 @@
+from policyengine_canada.model_api import *
+
+
+class on_health_premium(Variable):
+    value_type = float
+    entity = Person
+    label = "Ontario health premium"
+    unit = CAD
+    definition_period = YEAR
+    reference = "https://www.ontario.ca/laws/statute/07t11#BK8"
+    documentation = "The amount of the Ontario health premium"
+    defined_for = ProvinceCode.ONT
+
+    def formula(person, period, parameters):
+        income = person("on_taxable_income", period)
+        p = parameters(period).gov.provinces.on.tax.health_premium.rate
+        return p.calc(income)

--- a/policyengine_canada/variables/household/income/household/household_income_tax_before_refundable_credits.py
+++ b/policyengine_canada/variables/household/income/household/household_income_tax_before_refundable_credits.py
@@ -11,5 +11,6 @@ class household_income_tax_before_refundable_credits(Variable):
     adds = [
         "income_tax_before_refundable_credits",  # Federal.
         "on_income_tax_before_refundable_credits",  # Ontario.
+        "on_health_premium",  # Ontario.
         "bc_income_tax_before_refundable_credits",  # British Columbia.
     ]


### PR DESCRIPTION
- [X] `make format && make documentation` has been run.

# New variable

- [X] Label field added
- [X] Documentation field added
- [X] Unit field added
- [ ] Default value field added if relevant
- [X] Variable name follows conventions
- [X] Unit test(s) added
- [ ] Integration test(s) added if relevant
- [ ] Issues this PR fixes linked

## What's changed

Adds the [Ontario Health Premium](https://www.ontario.ca/page/health-premium). Note that despite the name, the OHP is just a tax and not actually an insurance premium ("The health premium is not linked to OHIP and does not affect a person’s eligibility to receive health care in Ontario").

See the [last page of Form ON428](https://www.canada.ca/content/dam/cra-arc/formspubs/pbg/5006-c/5006-c-22e.pdf) for how it is calculated.