### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Build changelog
         run: pip install yaml-changelog==0.3.0 && make changelog
       - name: Preview changelog update
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Build changelog
         run: pip install yaml-changelog==0.3.0 && make changelog
       - name: Preview changelog update
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Install package
         run: make install
       - name: Run tests
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Install Wheel and Pytest
         run: pip3 install wheel setuptools pytest==5.4.3
       - name: Install package

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Support for Python 3.13

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="Microsimulation model for Canada's tax-benefit system.",
@@ -62,7 +63,7 @@ setup(
     extras_require={
         "dev": dev_requirements,
     },
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10",
     install_requires=general_requirements,
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Summary
- Added Python 3.13 to classifiers in setup.py
- Updated GitHub Actions workflows to test on Python 3.13
- Added changelog entry for Python 3.13 support

Fixes #502

## Test plan
- CI tests will run on Python 3.13
- All existing tests should pass