### PR TITLE
Implement GST/HST and provincial sales taxes

### DIFF
--- a/policyengine_canada/parameters/gov/cra/tax/consumption/gst_hst/rate.yaml
+++ b/policyengine_canada/parameters/gov/cra/tax/consumption/gst_hst/rate.yaml
@@ -1,0 +1,38 @@
+description: GST/HST rate by province
+AB:
+  2020-01-01: 0.05
+BC:
+  2020-01-01: 0.05
+MB:
+  2020-01-01: 0.05
+NB:
+  2020-01-01: 0.15
+NL:
+  2020-01-01: 0.15
+NS:
+  2020-01-01: 0.15
+  2025-04-01: 0.14
+NT:
+  2020-01-01: 0.05
+NU:
+  2020-01-01: 0.05
+ONT:
+  2020-01-01: 0.13
+PE:
+  2020-01-01: 0.15
+QC:
+  2020-01-01: 0.05
+SK:
+  2020-01-01: 0.05
+YT:
+  2020-01-01: 0.05
+
+metadata:
+  unit: /1
+  period: year
+  label: GST/HST rate
+  reference:
+    - title: GST/HST rates by province
+      href: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/charge-collect-which-rate.html
+  breakdown:
+    - province_code

--- a/policyengine_canada/parameters/gov/provinces/sales_tax/pst_rate.yaml
+++ b/policyengine_canada/parameters/gov/provinces/sales_tax/pst_rate.yaml
@@ -1,0 +1,37 @@
+description: Provincial Sales Tax rate by province
+AB:
+  2020-01-01: 0  # No PST in Alberta
+BC:
+  2020-01-01: 0.07
+MB:
+  2020-01-01: 0.07
+NB:
+  2020-01-01: 0  # Uses HST instead
+NL:
+  2020-01-01: 0  # Uses HST instead
+NS:
+  2020-01-01: 0  # Uses HST instead
+NT:
+  2020-01-01: 0  # No PST in Northwest Territories
+NU:
+  2020-01-01: 0  # No PST in Nunavut
+ONT:
+  2020-01-01: 0  # Uses HST instead
+PE:
+  2020-01-01: 0  # Uses HST instead
+QC:
+  2020-01-01: 0.09975  # Quebec Sales Tax (QST)
+SK:
+  2020-01-01: 0.06
+YT:
+  2020-01-01: 0  # No PST in Yukon
+
+metadata:
+  unit: /1
+  period: year
+  label: Provincial Sales Tax rate
+  reference:
+    - title: Provincial sales tax rates
+      href: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/charge-collect-which-rate/calculator.html
+  breakdown:
+    - province_code

--- a/policyengine_canada/tests/gov/cra/tax/consumption/gst_hst.yaml
+++ b/policyengine_canada/tests/gov/cra/tax/consumption/gst_hst.yaml
@@ -1,0 +1,57 @@
+- name: Ontario household GST/HST
+  period: 2024
+  input:
+    province_code: ONT
+    consumption: 50_000
+  output:
+    # Ontario HST rate is 13%
+    # $50,000 * 0.13 = $6,500
+    gst_hst: 6_500
+
+- name: Alberta household GST only
+  period: 2024
+  input:
+    province_code: AB
+    consumption: 40_000
+  output:
+    # Alberta GST rate is 5%
+    # $40,000 * 0.05 = $2,000
+    gst_hst: 2_000
+
+- name: Nova Scotia household HST
+  period: 2024
+  input:
+    province_code: NS
+    consumption: 30_000
+  output:
+    # Nova Scotia HST rate is 15% in 2024
+    # $30,000 * 0.15 = $4,500
+    gst_hst: 4_500
+
+- name: British Columbia household GST
+  period: 2024
+  input:
+    province_code: BC
+    consumption: 60_000
+  output:
+    # BC GST rate is 5%
+    # $60,000 * 0.05 = $3,000
+    gst_hst: 3_000
+
+- name: New Brunswick household HST
+  period: 2024
+  input:
+    province_code: NB
+    consumption: 35_000
+  output:
+    # NB HST rate is 15%
+    # $35,000 * 0.15 = $5,250
+    gst_hst: 5_250
+
+- name: Zero consumption no tax
+  period: 2024
+  input:
+    province_code: ONT
+    consumption: 0
+  output:
+    gst_hst: 0

--- a/policyengine_canada/tests/gov/cra/tax/consumption/total_sales_tax.yaml
+++ b/policyengine_canada/tests/gov/cra/tax/consumption/total_sales_tax.yaml
@@ -1,0 +1,54 @@
+- name: Ontario total sales tax (HST only)
+  period: 2024
+  input:
+    province_code: ONT
+    consumption: 50_000
+  output:
+    # HST: $50,000 * 0.13 = $6,500
+    # PST: $0 (uses HST)
+    # Total: $6,500
+    total_sales_tax: 6_500
+
+- name: British Columbia total sales tax (GST + PST)
+  period: 2024
+  input:
+    province_code: BC
+    consumption: 50_000
+  output:
+    # GST: $50,000 * 0.05 = $2,500
+    # PST: $50,000 * 0.07 = $3,500
+    # Total: $6,000
+    total_sales_tax: 6_000
+
+- name: Quebec total sales tax (GST + QST)
+  period: 2024
+  input:
+    province_code: QC
+    consumption: 40_000
+  output:
+    # GST: $40,000 * 0.05 = $2,000
+    # QST: $40,000 * 0.09975 = $3,990
+    # Total: $5,990
+    total_sales_tax: 5_990
+
+- name: Alberta total sales tax (GST only)
+  period: 2024
+  input:
+    province_code: AB
+    consumption: 60_000
+  output:
+    # GST: $60,000 * 0.05 = $3,000
+    # PST: $0 (no PST in Alberta)
+    # Total: $3,000
+    total_sales_tax: 3_000
+
+- name: Nova Scotia total sales tax (HST only)
+  period: 2024
+  input:
+    province_code: NS
+    consumption: 30_000
+  output:
+    # HST: $30,000 * 0.15 = $4,500
+    # PST: $0 (uses HST)
+    # Total: $4,500
+    total_sales_tax: 4_500

--- a/policyengine_canada/tests/gov/provinces/tax/provincial_sales_tax.yaml
+++ b/policyengine_canada/tests/gov/provinces/tax/provincial_sales_tax.yaml
@@ -1,0 +1,57 @@
+- name: British Columbia PST
+  period: 2024
+  input:
+    province_code: BC
+    consumption: 50_000
+  output:
+    # BC PST rate is 7%
+    # $50,000 * 0.07 = $3,500
+    provincial_sales_tax: 3_500
+
+- name: Quebec QST
+  period: 2024
+  input:
+    province_code: QC
+    consumption: 40_000
+  output:
+    # Quebec Sales Tax rate is 9.975%
+    # $40,000 * 0.09975 = $3,990
+    provincial_sales_tax: 3_990
+
+- name: Saskatchewan PST
+  period: 2024
+  input:
+    province_code: SK
+    consumption: 30_000
+  output:
+    # SK PST rate is 6%
+    # $30,000 * 0.06 = $1,800
+    provincial_sales_tax: 1_800
+
+- name: Manitoba PST
+  period: 2024
+  input:
+    province_code: MB
+    consumption: 45_000
+  output:
+    # MB PST rate is 7%
+    # $45,000 * 0.07 = $3,150
+    provincial_sales_tax: 3_150
+
+- name: Ontario no PST (uses HST)
+  period: 2024
+  input:
+    province_code: ONT
+    consumption: 50_000
+  output:
+    # Ontario uses HST, no separate PST
+    provincial_sales_tax: 0
+
+- name: Alberta no PST
+  period: 2024
+  input:
+    province_code: AB
+    consumption: 60_000
+  output:
+    # Alberta has no PST
+    provincial_sales_tax: 0

--- a/policyengine_canada/variables/gov/cra/tax/consumption/gst_hst.py
+++ b/policyengine_canada/variables/gov/cra/tax/consumption/gst_hst.py
@@ -1,0 +1,21 @@
+from policyengine_canada.model_api import *
+
+
+class gst_hst(Variable):
+    value_type = float
+    entity = Household
+    label = "GST/HST paid"
+    definition_period = YEAR
+    unit = CAD
+    documentation = "Goods and Services Tax / Harmonized Sales Tax paid on consumption"
+    
+    def formula(household, period, parameters):
+        consumption = household("consumption", period)
+        province = household("province_code_str", period)
+        p = parameters(period).gov.cra.tax.consumption.gst_hst
+        
+        # Get the GST/HST rate for the province
+        rate = p.rate[province]
+        
+        # Calculate GST/HST paid
+        return consumption * rate

--- a/policyengine_canada/variables/gov/cra/tax/consumption/total_sales_tax.py
+++ b/policyengine_canada/variables/gov/cra/tax/consumption/total_sales_tax.py
@@ -1,0 +1,11 @@
+from policyengine_canada.model_api import *
+
+
+class total_sales_tax(Variable):
+    value_type = float
+    entity = Household
+    label = "Total sales tax paid"
+    definition_period = YEAR
+    unit = CAD
+    documentation = "Total sales tax paid including GST/HST and PST"
+    adds = ["gst_hst", "provincial_sales_tax"]

--- a/policyengine_canada/variables/gov/provinces/tax/provincial_sales_tax.py
+++ b/policyengine_canada/variables/gov/provinces/tax/provincial_sales_tax.py
@@ -1,0 +1,21 @@
+from policyengine_canada.model_api import *
+
+
+class provincial_sales_tax(Variable):
+    value_type = float
+    entity = Household
+    label = "Provincial sales tax paid"
+    definition_period = YEAR
+    unit = CAD
+    documentation = "Provincial Sales Tax (PST/QST) paid on consumption"
+    
+    def formula(household, period, parameters):
+        consumption = household("consumption", period)
+        province = household("province_code_str", period)
+        p = parameters(period).gov.provinces.sales_tax
+        
+        # Get the PST rate for the province
+        rate = p.pst_rate[province]
+        
+        # Calculate PST paid
+        return consumption * rate

--- a/policyengine_canada/variables/household/expense/consumption.py
+++ b/policyengine_canada/variables/household/expense/consumption.py
@@ -1,0 +1,10 @@
+from policyengine_canada.model_api import *
+
+
+class consumption(Variable):
+    value_type = float
+    entity = Household
+    label = "Household consumption"
+    definition_period = YEAR
+    unit = CAD
+    documentation = "Total household consumption spending subject to sales tax"


### PR DESCRIPTION
## Summary
- Implements Goods and Services Tax (GST) / Harmonized Sales Tax (HST)
- Implements Provincial Sales Tax (PST/QST)
- Part of achieving SPSD/M parity (#517, #518)

## Changes

### Parameters Added
- GST/HST rates for all provinces (5% federal, up to 15% harmonized)
- Provincial sales tax rates (BC 7%, MB 7%, QC 9.975%, SK 6%)

### Variables Added
- `consumption`: Household consumption spending subject to sales tax
- `gst_hst`: GST/HST paid on consumption
- `provincial_sales_tax`: PST/QST paid on consumption  
- `total_sales_tax`: Total sales tax (GST/HST + PST)

### Test Coverage
- GST/HST tests for 6 provinces
- PST tests for provinces with separate sales tax
- Total sales tax integration tests

## Implementation Notes
- HST provinces (ON, NB, NS, NL, PE) have combined federal-provincial tax
- GST+PST provinces (BC, MB, SK) have separate taxes
- Quebec has GST + QST (Quebec Sales Tax)
- Alberta, NWT, NU, YT have GST only (no provincial tax)

## References
- [GST/HST rates by province](https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/charge-collect-which-rate.html)

🤖 Generated with [Claude Code](https://claude.ai/code)