### PR TITLE
Switch code formatter from Black to Ruff

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check formatting
-        uses: "lgeiger/black-action@master"
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          args: ". -l 79 --check"
+          python-version: "3.14"
+          allow-prereleases: true
+      - name: Install ruff
+        run: pip install "ruff>=0.9.0"
+      - name: Check formatting
+        run: ruff format --check .
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,10 +10,15 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine Canada')
     steps:
       - uses: actions/checkout@v4
-      - name: Check formatting
-        uses: "lgeiger/black-action@master"
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          args: ". -l 79 --check"
+          python-version: "3.14"
+          allow-prereleases: true
+      - name: Install ruff
+        run: pip install "ruff>=0.9.0"
+      - name: Check formatting
+        run: ruff format --check .
   versioning:
     name: Update versioning
     if: |

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ documentation:
 	jupyter-book build docs
 
 format:
-	black . -l 79
-	linecheck . --fix
+	ruff format .
 
 install:
 	pip install -e .[dev]

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switch code formatter from Black to Ruff.

--- a/policyengine_canada/data/datasets/country_template_dataset.py
+++ b/policyengine_canada/data/datasets/country_template_dataset.py
@@ -10,11 +10,7 @@ class CountryTemplateDataset(Dataset):
     label = "Country template dataset"
     folder_path = COUNTRY_DIR / "data" / "storage"
     data_format = Dataset.TIME_PERIOD_ARRAYS
-    file_path = (
-        Path(__file__).parent.parent
-        / "storage"
-        / "country_template_dataset.h5"
-    )
+    file_path = Path(__file__).parent.parent / "storage" / "country_template_dataset.h5"
 
     # The generation function is the most important part: it defines
     # how the dataset is generated from the raw data for a given year.

--- a/policyengine_canada/variables/gov/cra/benefits/ccb/child_benefit_base_person.py
+++ b/policyengine_canada/variables/gov/cra/benefits/ccb/child_benefit_base_person.py
@@ -13,6 +13,4 @@ class child_benefit_base_person(Variable):
         age = person("age", period)
         p = parameters(period).gov.cra.benefits.ccb
         full_custody = person("full_custody", period)
-        return where(
-            full_custody, p.base.calc(age), p.base.calc(age) / p.divisor
-        )
+        return where(full_custody, p.base.calc(age), p.base.calc(age) / p.divisor)

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_category.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_category.py
@@ -20,9 +20,7 @@ class cwb_disability_category(Variable):
         person = household.members
         # Compute individual-level eligibility among heads/spouses.
         head_or_spouse = person("is_head_or_spouse", period)
-        disability_eligible = person(
-            "cwb_disability_supplement_eligible", period
-        )
+        disability_eligible = person("cwb_disability_supplement_eligible", period)
         cwb_family = household("is_cwb_family", period)
         eligible_spouses = household.sum(head_or_spouse * disability_eligible)
         return select(

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_eligible.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_eligible.py
@@ -6,9 +6,7 @@ class cwb_disability_supplement_eligible(Variable):
     entity = Person
     label = "Eligible for canada workers benefit supplement"
     definition_period = YEAR
-    reference = (
-        "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-89.html#docCont"
-    )
+    reference = "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-89.html#docCont"
 
     def formula(person, period, parameters):
         # For now, apply a person-level logic based on age.

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_max_amount.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_max_amount.py
@@ -6,15 +6,11 @@ class cwb_disability_supplement_max_amount(Variable):
     entity = Household
     label = "Eligible for canada workers benefit supplement"
     definition_period = YEAR
-    reference = (
-        "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-89.html#docCont"
-    )
+    reference = "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-89.html#docCont"
     unit = CAD
 
     def formula(household, period, parameters):
         person = household.members
         eligible = person("cwb_disability_supplement_eligible", period)
-        amount = parameters(
-            period
-        ).gov.cra.benefits.cwb.amount.disability_supplement
+        amount = parameters(period).gov.cra.benefits.cwb.amount.disability_supplement
         return household.sum(eligible * amount)

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_phase_in.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_phase_in.py
@@ -10,7 +10,5 @@ class cwb_disability_supplement_phase_in(Variable):
 
     def formula(household, period, parameters):
         income = household("family_working_income", period)
-        p = parameters(
-            period
-        ).gov.cra.benefits.cwb.phase_in.disability_supplement
+        p = parameters(period).gov.cra.benefits.cwb.phase_in.disability_supplement
         return p.calc(income)

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_phase_out.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/disability_supplement/cwb_disability_supplement_phase_out.py
@@ -10,9 +10,7 @@ class cwb_disability_supplement_phase_out(Variable):
 
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
-        p = parameters(
-            period
-        ).gov.cra.benefits.cwb.phase_out.disability_supplement
+        p = parameters(period).gov.cra.benefits.cwb.phase_out.disability_supplement
         category = household("cwb_disability_category", period)
         categories = category.possible_values
         return select(

--- a/policyengine_canada/variables/gov/cra/benefits/cwb/family_working_income.py
+++ b/policyengine_canada/variables/gov/cra/benefits/cwb/family_working_income.py
@@ -9,8 +9,6 @@ class family_working_income(Variable):
     documentation = "Income from employment and self-employment of a family"
     definition_period = YEAR
     # A.2.(122.7)(1.1)
-    reference = (
-        "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-96.html#h-299725"
-    )
+    reference = "https://laws-lois.justice.gc.ca/eng/acts/I-3.3/page-96.html#h-299725"
 
     adds = ["working_income"]

--- a/policyengine_canada/variables/gov/cra/benefits/old_age_security_pension/oas_eligibility.py
+++ b/policyengine_canada/variables/gov/cra/benefits/old_age_security_pension/oas_eligibility.py
@@ -6,15 +6,13 @@ class oas_eligibility(Variable):
     entity = Person
     label = "Old age security pension eligibility"
     unit = CAD
-    documentation = "Eligibility for the OAS based on age and adult years resident in canada"
+    documentation = (
+        "Eligibility for the OAS based on age and adult years resident in canada"
+    )
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.cra.benefits.old_age_security_pension.eligibility
+        p = parameters(period).gov.cra.benefits.old_age_security_pension.eligibility
         age_eligible = person("age", period) >= p.age.base
-        residency_eligible = (
-            person("adult_years_in_canada", period) >= p.residence.any
-        )
+        residency_eligible = person("adult_years_in_canada", period) >= p.residence.any
         return age_eligible & residency_eligible

--- a/policyengine_canada/variables/gov/cra/benefits/old_age_security_pension/oas_pre_repayment.py
+++ b/policyengine_canada/variables/gov/cra/benefits/old_age_security_pension/oas_pre_repayment.py
@@ -20,8 +20,7 @@ class oas_pre_repayment(Variable):
         older_increase_age_threshold = p.eligibility.age.older_seniors_increase
         eligible_older_increase = age >= older_increase_age_threshold
         total_older_increase_factor = (
-            1
-            + eligible_older_increase * p.amount.older_seniors_increase_factor
+            1 + eligible_older_increase * p.amount.older_seniors_increase_factor
         )
         base_amount = p.amount.base
         # Your full base amount is your number of adult residence years divided

--- a/policyengine_canada/variables/gov/cra/deductions/child_care_expense/child_care_expense_deduction.py
+++ b/policyengine_canada/variables/gov/cra/deductions/child_care_expense/child_care_expense_deduction.py
@@ -18,9 +18,7 @@ class child_care_expense_deduction(Variable):
 
         # Step 1: Cap each child's expenses at their per-child maximum
         expenses = person("childcare_expense", period)
-        max_per_child = person(
-            "child_care_expense_deduction_max_per_child", period
-        )
+        max_per_child = person("child_care_expense_deduction_max_per_child", period)
         capped_expenses = min_(expenses, max_per_child)
         total_household_expenses = household.sum(capped_expenses)
 

--- a/policyengine_canada/variables/gov/cra/deductions/child_care_expense/is_child_care_expense_claimant.py
+++ b/policyengine_canada/variables/gov/cra/deductions/child_care_expense/is_child_care_expense_claimant.py
@@ -28,7 +28,5 @@ class is_child_care_expense_claimant(Variable):
         # Use person_index as a deterministic tiebreaker when two
         # earners have equal income: lowest index claims.
         person_idx = person("person_index", period)
-        min_idx_among_lowest = household.min(
-            where(is_lowest_earner, person_idx, inf)
-        )
+        min_idx_among_lowest = household.min(where(is_lowest_earner, person_idx, inf))
         return is_lowest_earner & (person_idx == min_idx_among_lowest)

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/canada_employment_amount.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/canada_employment_amount.py
@@ -10,9 +10,7 @@ class canada_employment_amount(Variable):
     reference = "https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/deductions-credits-expenses/line-31260-canada-employment-amount.html"
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.cra.tax.income.credits.canada_employment_amount
+        p = parameters(period).gov.cra.tax.income.credits.canada_employment_amount
         # While the government website states that the Canada Employment Amount is designed
         # to support workers with work-related expenses, those expenses are not part of the formula.
         countable_income = add(person, period, p.income_sources)

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/climate_action_incentive_category.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/climate_action_incentive_category.py
@@ -4,9 +4,7 @@ from policyengine_canada.model_api import *
 class ClimateActionIncentiveCategory(Enum):
     HEAD = "Head"
     SPOUSE = "Spouse"
-    ELDEST_CHILD_IN_SINGLE_PARENT_HOUSEHOLD = (
-        "Eldest child in single parent household"
-    )
+    ELDEST_CHILD_IN_SINGLE_PARENT_HOUSEHOLD = "Eldest child in single parent household"
     OTHER_CHILD = "Other child"
 
 
@@ -22,9 +20,7 @@ class climate_action_incentive_category(Variable):
         is_single_parent_household = person.household(
             "climate_action_incentive_single_parent_household", period
         )
-        eldest_child = person(
-            "is_eldest_child_for_climate_action_incentive", period
-        )
+        eldest_child = person("is_eldest_child_for_climate_action_incentive", period)
         eldest_child_in_single_parent_household = (
             is_single_parent_household & eldest_child
         )

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/climate_action_incentive_single_parent_household.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/climate_action_incentive_single_parent_household.py
@@ -11,7 +11,5 @@ class climate_action_incentive_single_parent_household(Variable):
 
     def formula(household, period, parameters):
         married = household("is_married", period)
-        cai_children = household(
-            "climate_action_incentive_dependant_children", period
-        )
+        cai_children = household("climate_action_incentive_dependant_children", period)
         return ~married & (cai_children > 0)

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/is_child_for_climate_action_incentive.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/climate_action/is_child_for_climate_action_incentive.py
@@ -4,9 +4,7 @@ from policyengine_canada.model_api import *
 class is_child_for_climate_action_incentive(Variable):
     value_type = bool
     entity = Person
-    label = (
-        "Is a for the climate action incentive eligible child in a Household"
-    )
+    label = "Is a for the climate action incentive eligible child in a Household"
     definition_period = YEAR
     defined_for = "is_dependant"
 

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/dtc/dtc_child_supplement.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/dtc/dtc_child_supplement.py
@@ -11,7 +11,5 @@ class dtc_child_supplement(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.cra.tax.income.credits.dtc
-        supplement_eligible = (
-            person("age", period) < p.supplement_ineligible_age
-        )
+        supplement_eligible = person("age", period) < p.supplement_ineligible_age
         return p.child_supplement * supplement_eligible

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_person.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_person.py
@@ -11,7 +11,5 @@ class gst_credit_person(Variable):
 
     def formula(person, period, parameters):
         category = person("gst_credit_category", period)
-        amounts = parameters(
-            period
-        ).gov.cra.tax.income.credits.gst_credit.base_amounts
+        amounts = parameters(period).gov.cra.tax.income.credits.gst_credit.base_amounts
         return amounts[category]

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_single_parent_household.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_single_parent_household.py
@@ -11,7 +11,5 @@ class gst_credit_single_parent_household(Variable):
 
     def formula(household, period, parameters):
         married = household("is_married", period)
-        gst_credit_children = household(
-            "gst_credit_dependant_children", period
-        )
+        gst_credit_children = household("gst_credit_dependant_children", period)
         return ~married & (gst_credit_children > 0)

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_singles_boost.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/gst_credit_singles_boost.py
@@ -15,13 +15,9 @@ class gst_credit_singles_boost(Variable):
             "gst_credit_single_parent_household", period
         )
         net_income = household("household_net_income", period)
-        p = parameters(
-            period
-        ).gov.cra.tax.income.credits.gst_credit.singles_boost
+        p = parameters(period).gov.cra.tax.income.credits.gst_credit.singles_boost
         singles_phase_in = p.phase_in.calc(net_income)
         singles_amount = min_(p.cap, singles_phase_in)
-        amount_if_single = where(
-            single_parent_household, p.cap, singles_amount
-        )
+        amount_if_single = where(single_parent_household, p.cap, singles_amount)
         eligible = ~household("is_married", period)
         return eligible * amount_if_single

--- a/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/is_child_for_gst_credit.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/credits/gst_credit/is_child_for_gst_credit.py
@@ -10,7 +10,5 @@ class is_child_for_gst_credit(Variable):
     def formula(person, period, parameters):
         dependant = person("is_dependant", period)
         age = person("age", period)
-        adult_age = parameters(
-            period
-        ).gov.cra.tax.income.credits.gst_credit.adult_age
+        adult_age = parameters(period).gov.cra.tax.income.credits.gst_credit.adult_age
         return dependant & (age < adult_age)

--- a/policyengine_canada/variables/gov/cra/tax/income/income_tax_before_refundable_credits.py
+++ b/policyengine_canada/variables/gov/cra/tax/income/income_tax_before_refundable_credits.py
@@ -10,7 +10,5 @@ class income_tax_before_refundable_credits(Variable):
 
     def formula(person, period, parameters):
         income_tax_before_credits = person("income_tax_before_credits", period)
-        non_refundable_tax_credits = person(
-            "non_refundable_tax_credits", period
-        )
+        non_refundable_tax_credits = person("non_refundable_tax_credits", period)
         return max_(income_tax_before_credits - non_refundable_tax_credits, 0)

--- a/policyengine_canada/variables/gov/provinces/ab/benefits/acfb/acfb_base_component_base.py
+++ b/policyengine_canada/variables/gov/provinces/ab/benefits/acfb/acfb_base_component_base.py
@@ -9,9 +9,7 @@ class acfb_base_component_base(Variable):
     defined_for = ProvinceCode.AB
 
     def formula(household, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.ab.benefits.acfb.base_component.base
+        p = parameters(period).gov.provinces.ab.benefits.acfb.base_component.base
         eligible_children = household("acfb_eligible_children", period)
         return (
             (p.one_child * (eligible_children > 0))

--- a/policyengine_canada/variables/gov/provinces/ab/benefits/acfb/acfb_base_component_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/ab/benefits/acfb/acfb_base_component_reduction.py
@@ -9,9 +9,7 @@ class acfb_base_component_reduction(Variable):
     defined_for = ProvinceCode.AB
 
     def formula(household, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.ab.benefits.acfb.base_component.phase_out
+        p = parameters(period).gov.provinces.ab.benefits.acfb.base_component.phase_out
         income = household("adjusted_family_net_income", period)
         children = household("acfb_eligible_children", period)
         return select(

--- a/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/basic_personal_amount/ab_basic_personal_amount.py
+++ b/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/basic_personal_amount/ab_basic_personal_amount.py
@@ -7,7 +7,9 @@ class ab_basic_personal_amount(Variable):
     label = "Alberta basic personal amount"
     unit = CAD
     definition_period = YEAR
-    reference = "https://www.canada.ca/content/dam/cra-arc/formspubs/pbg/td1ab/td1ab-23e.pdf"
+    reference = (
+        "https://www.canada.ca/content/dam/cra-arc/formspubs/pbg/td1ab/td1ab-23e.pdf"
+    )
     defined_for = ProvinceCode.AB
 
     def formula(person, period, parameters):

--- a/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/disability/ab_disability_credit.py
+++ b/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/disability/ab_disability_credit.py
@@ -12,8 +12,6 @@ class ab_disability_credit(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.provinces.ab.tax.income.credits.disability
-        additional_amount = person(
-            "ab_disability_credit_additional_amount", period
-        )
+        additional_amount = person("ab_disability_credit_additional_amount", period)
         uncapped_amount = p.base + additional_amount
         return min_(p.cap, uncapped_amount)

--- a/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/disability/ab_disability_credit_additional_amount.py
+++ b/policyengine_canada/variables/gov/provinces/ab/tax/income/credits/disability/ab_disability_credit_additional_amount.py
@@ -15,8 +15,7 @@ class ab_disability_credit_additional_amount(Variable):
         childcare_expenses = person("care_expenses", period)
         excess_childcare_expenses = max_(
             0,
-            childcare_expenses
-            - p.additional_amount.childcare_expense_threshold,
+            childcare_expenses - p.additional_amount.childcare_expense_threshold,
         )
         age = person("age", period)
         additional_amount_base = p.additional_amount.base.calc(age)

--- a/policyengine_canada/variables/gov/provinces/bc/benefits/child_care/bc_affordable_child_care_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/bc/benefits/child_care/bc_affordable_child_care_benefit.py
@@ -20,8 +20,7 @@ class bc_affordable_child_care_benefit(Variable):
         income = household("adjusted_family_net_income", period)
         household_size = household("household_size", period)
         family_size_adjustment = (
-            max_(0, household_size - p.base_family_size)
-            * p.family_size_adjustment
+            max_(0, household_size - p.base_family_size) * p.family_size_adjustment
         )
         adjusted_income = max_(0, income - family_size_adjustment)
 

--- a/policyengine_canada/variables/gov/provinces/bc/benefits/child_care/bc_child_care_fee_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/bc/benefits/child_care/bc_child_care_fee_reduction.py
@@ -14,9 +14,7 @@ class bc_child_care_fee_reduction(Variable):
     )
 
     def formula(household, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.bc.benefits.child_care_fee_reduction
+        p = parameters(period).gov.provinces.bc.benefits.child_care_fee_reduction
 
         person = household.members
         age = person("age", period)

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/bc_income_tax_before_refundable_credits.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/bc_income_tax_before_refundable_credits.py
@@ -11,10 +11,6 @@ class bc_income_tax_before_refundable_credits(Variable):
     defined_for = ProvinceCode.BC
 
     def formula(person, period, parameters):
-        income_tax_before_credits = person(
-            "bc_income_tax_before_credits", period
-        )
-        non_refundable_tax_credits = person(
-            "bc_non_refundable_credits", period
-        )
+        income_tax_before_credits = person("bc_income_tax_before_credits", period)
+        non_refundable_tax_credits = person("bc_non_refundable_credits", period)
         return max_(income_tax_before_credits - non_refundable_tax_credits, 0)

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/basic_personal_amount/bc_basic_personal_amount.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/basic_personal_amount/bc_basic_personal_amount.py
@@ -11,7 +11,5 @@ class bc_basic_personal_amount(Variable):
     defined_for = ProvinceCode.BC
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.bc.tax.income.credits.basic_personal_amount
+        p = parameters(period).gov.provinces.bc.tax.income.credits.basic_personal_amount
         return p.base

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_disability_credit/bc_disability_credit.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_disability_credit/bc_disability_credit.py
@@ -12,7 +12,5 @@ class bc_disability_credit(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.provinces.bc.tax.income.credits.disability
-        additional_amount = person(
-            "bc_disability_credit_additional_amount", period
-        )
+        additional_amount = person("bc_disability_credit_additional_amount", period)
         return p.base + additional_amount

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_disability_credit/bc_disability_credit_additional_amount.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_disability_credit/bc_disability_credit_additional_amount.py
@@ -14,8 +14,7 @@ class bc_disability_credit_additional_amount(Variable):
         p = parameters(period).gov.provinces.bc.tax.income.credits.disability
         childcare_expenses = person("care_expenses", period)
         reduced_childcare_expenses = (
-            childcare_expenses
-            - p.additional_amount.childcare_expense_threshold
+            childcare_expenses - p.additional_amount.childcare_expense_threshold
         )
         excess_childcare_expenses = max_(
             0,

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_tax_reduction_credit/bc_tax_reduction_credit.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bc_tax_reduction_credit/bc_tax_reduction_credit.py
@@ -11,7 +11,5 @@ class bc_tax_reduction_credit(Variable):
 
     def formula(person, period, parameters):
         income = person("bc_taxable_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.bc.tax.income.credits.tax_reduction
+        p = parameters(period).gov.provinces.bc.tax.income.credits.tax_reduction
         return max_(p.base - p.reduction.calc(income), 0)

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bccatc/bc_climate_action_incentive_category.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bccatc/bc_climate_action_incentive_category.py
@@ -4,9 +4,7 @@ from policyengine_canada.model_api import *
 class BCClimateActionIncentiveCategory(Enum):
     HEAD = "Head"
     SPOUSE = "Spouse"
-    ELDEST_CHILD_IN_SINGLE_PARENT_HOUSEHOLD = (
-        "Eldest child in single parent household"
-    )
+    ELDEST_CHILD_IN_SINGLE_PARENT_HOUSEHOLD = "Eldest child in single parent household"
     OTHER_CHILD = "Other child"
 
 

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bccatc/bc_climate_action_tax_credit_person.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/bccatc/bc_climate_action_tax_credit_person.py
@@ -12,7 +12,5 @@ class bc_climate_action_tax_credit_person(Variable):
 
     def formula(person, period, parameters):
         category = person("bc_climate_action_incentive_category", period)
-        amounts = parameters(
-            period
-        ).gov.provinces.bc.tax.income.credits.bccatc.amount
+        amounts = parameters(period).gov.provinces.bc.tax.income.credits.bccatc.amount
         return amounts[category]

--- a/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/pension_income_amount/bc_pension_income_amount.py
+++ b/policyengine_canada/variables/gov/provinces/bc/tax/income/credits/pension_income_amount/bc_pension_income_amount.py
@@ -11,8 +11,6 @@ class bc_pension_income_amount(Variable):
 
     def formula(person, period, parameters):
         pension_income = person("pension_and_savings_plan_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.bc.tax.income.credits.pension_income_amount
+        p = parameters(period).gov.provinces.bc.tax.income.credits.pension_income_amount
         # Capped at a certain amount
         return min_(p.cap, pension_income)

--- a/policyengine_canada/variables/gov/provinces/mb/tax/income/benefits/child_benefit/mb_child_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/mb/tax/income/benefits/child_benefit/mb_child_benefit.py
@@ -9,9 +9,7 @@ class mb_child_benefit(Variable):
     defined_for = ProvinceCode.MB
 
     def formula(household, period, parameters):
-        eligible_children = household(
-            "mb_child_benefit_eligible_children", period
-        )
+        eligible_children = household("mb_child_benefit_eligible_children", period)
         p = parameters(period).gov.provinces.mb.benefits.mbcb
         capped_children_count = min_(eligible_children, p.max_child_count)
         # <= 6

--- a/policyengine_canada/variables/gov/provinces/mb/tax/income/credits/age_amount/mb_age_credit.py
+++ b/policyengine_canada/variables/gov/provinces/mb/tax/income/credits/age_amount/mb_age_credit.py
@@ -7,7 +7,9 @@ class mb_age_credit(Variable):
     label = "Manitoba age credit amount"
     definition_period = YEAR
     defined_for = "mb_age_credit_eligible"
-    reference = "https://www.cchwebsites.com/content/pdf/tax_forms/ca/en/td1mbws_en.pdf#page=1"
+    reference = (
+        "https://www.cchwebsites.com/content/pdf/tax_forms/ca/en/td1mbws_en.pdf#page=1"
+    )
 
     def formula(person, period, parameters):
         age = person("age", period)

--- a/policyengine_canada/variables/gov/provinces/mb/tax/income/credits/pension_amount/mb_pension_amount_credit.py
+++ b/policyengine_canada/variables/gov/provinces/mb/tax/income/credits/pension_amount/mb_pension_amount_credit.py
@@ -10,9 +10,7 @@ class mb_pension_amount_credit(Variable):
     defined_for = ProvinceCode.MB
 
     def formula(person, period, parameters):
-        pension_and_savings_income = person(
-            "pension_and_savings_plan_income", period
-        )
+        pension_and_savings_income = person("pension_and_savings_plan_income", period)
         max_amount = parameters(
             period
         ).gov.provinces.mb.tax.income.credits.pension_amount.max_amount

--- a/policyengine_canada/variables/gov/provinces/nb/benefits/nbcb/nb_child_benefit_eligible_child.py
+++ b/policyengine_canada/variables/gov/provinces/nb/benefits/nbcb/nb_child_benefit_eligible_child.py
@@ -10,7 +10,4 @@ class nb_child_benefit_eligible_child(Variable):
 
     def formula(person, period, parameters):
         age = person("age", period)
-        return (
-            age
-            < parameters(period).gov.provinces.nb.benefits.nbcb.eligible_age
-        )
+        return age < parameters(period).gov.provinces.nb.benefits.nbcb.eligible_age

--- a/policyengine_canada/variables/gov/provinces/nb/benefits/nbcb/nb_child_benefit_supplement.py
+++ b/policyengine_canada/variables/gov/provinces/nb/benefits/nbcb/nb_child_benefit_supplement.py
@@ -10,9 +10,7 @@ class nb_child_benefit_supplement(Variable):
 
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.nb.benefits.nbcb.working_income_supplement
+        p = parameters(period).gov.provinces.nb.benefits.nbcb.working_income_supplement
         working_income = household("family_working_income", period)
         # the supplement amount is reduced by 4% of "family earned income" in excess of $3,750 minus 5% of "family net income" in excess of $20,921.
         reduced_amount = max_(

--- a/policyengine_canada/variables/gov/provinces/nb/benefits/pension_benefit/nb_pension_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/nb/benefits/pension_benefit/nb_pension_benefit.py
@@ -12,8 +12,6 @@ class nb_pension_benefit(Variable):
     def formula(person, period, parameters):
         age = person("age", period)
         pension_income = person("pension_and_savings_plan_income", period)
-        max_amount = parameters(
-            period
-        ).gov.provinces.nb.benefits.pension_benefit.cap
+        max_amount = parameters(period).gov.provinces.nb.benefits.pension_benefit.cap
         # Capped at a certain amount
         return min_(max_amount, pension_income)

--- a/policyengine_canada/variables/gov/provinces/nb/tax/income/credits/low_income_tax_reduction/nb_low_income_tax_reduction_base.py
+++ b/policyengine_canada/variables/gov/provinces/nb/tax/income/credits/low_income_tax_reduction/nb_low_income_tax_reduction_base.py
@@ -17,7 +17,5 @@ class nb_low_income_tax_reduction_base(Variable):
         dependant = person("is_dependant", period)
         return min_(
             p.base.max_amount,
-            p.base.head
-            + married * p.base.spouse
-            + dependant * p.base.dependant,
+            p.base.head + married * p.base.spouse + dependant * p.base.dependant,
         )

--- a/policyengine_canada/variables/gov/provinces/nl/tax/income/credit/nl_physical_activity_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/nl/tax/income/credit/nl_physical_activity_tax_credit.py
@@ -10,9 +10,7 @@ class nl_physical_activity_tax_credit(Variable):
 
     def formula(household, period, parameters):
         person = household.members
-        p = parameters(
-            period
-        ).gov.provinces.nl.tax.income.credits.physical_activity
+        p = parameters(period).gov.provinces.nl.tax.income.credits.physical_activity
 
         # Person has to be either head, spouse or child under 18 to be eligible.
         eligible = (
@@ -21,9 +19,7 @@ class nl_physical_activity_tax_credit(Variable):
             | (person("age", period) < p.age_eligible)
         )
 
-        individual_expenses = eligible * (
-            person("physical_activities_fees", period)
-        )
+        individual_expenses = eligible * (person("physical_activities_fees", period))
 
         expenses = household.sum(individual_expenses)
         maximum_amount = min_(expenses, p.max_amount)

--- a/policyengine_canada/variables/gov/provinces/ns/benefits/child_benefit/ns_child_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/ns/benefits/child_benefit/ns_child_benefit.py
@@ -21,9 +21,7 @@ class ns_child_benefit(Variable):
         higher_income_base = p.base * (children > 0)
         # In the higher income bracket, families are eligible to receive
         # $637.50 for each child after the first born.
-        higher_income_additional_child = max_(
-            0, p.higher_income_base * (children - 1)
-        )
+        higher_income_additional_child = max_(0, p.higher_income_base * (children - 1))
         amount_if_eligible = where(
             income < p.lower_threshold,
             lower_income_amount,

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/age/ns_age_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/age/ns_age_tax_credit.py
@@ -12,8 +12,6 @@ class ns_age_tax_credit(Variable):
         age = person("age", period)
         income = person("ns_taxable_income", period)
         p = parameters(period).gov.provinces.ns.tax.income.credits.age
-        eligibility = (age >= p.age_eligibility) & (
-            income < p.income_eligibility
-        )
+        eligibility = (age >= p.age_eligibility) & (income < p.income_eligibility)
 
         return eligibility * p.amount

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction.py
@@ -10,8 +10,6 @@ class ns_low_income_tax_reduction(Variable):
 
     def formula(household, period, parameters):
         base = household("ns_low_income_tax_reduction_base", period)
-        children = household(
-            "ns_low_income_tax_reduction_base_children", period
-        )
+        children = household("ns_low_income_tax_reduction_base_children", period)
         reduction = household("ns_low_income_tax_reduction_reduction", period)
         return max_(0, (base + children) - reduction)

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction_base.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction_base.py
@@ -22,7 +22,5 @@ class ns_low_income_tax_reduction_base(Variable):
         dependant_amount = dependant * p.base.eligible_dependant
         return min_(
             p.base.max_amount,
-            household.sum(
-                eligible * (base + spouse_amount + dependant_amount)
-            ),
+            household.sum(eligible * (base + spouse_amount + dependant_amount)),
         )

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction_base_children.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/low_income_tax_reduction/ns_low_income_tax_reduction_base_children.py
@@ -12,7 +12,5 @@ class ns_low_income_tax_reduction_base_children(Variable):
         p = parameters(
             period
         ).gov.provinces.ns.tax.income.credits.low_income_tax_reduction
-        children = household(
-            "ns_low_income_tax_reduction_eligible_children", period
-        )
+        children = household("ns_low_income_tax_reduction_eligible_children", period)
         return children * p.base.dependant.base

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/ns_disability_amount.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/ns_disability_amount.py
@@ -11,8 +11,6 @@ class ns_disability_amount(Variable):
     reference = "https://hr.acadiau.ca/files/sites/hr/Payroll/Pensions%20&%20Benefits/NS_TD1_2022.pdf#page=1"
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.ns.tax.income.credits.disability_amount
+        p = parameters(period).gov.provinces.ns.tax.income.credits.disability_amount
         is_disabled = person("is_disabled", period)
         return p.base * is_disabled

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/ns_pension_income_amount.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/ns_pension_income_amount.py
@@ -15,12 +15,8 @@ class ns_pension_income_amount(Variable):
     )
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.ns.tax.income.credits.pension_income_amount
+        p = parameters(period).gov.provinces.ns.tax.income.credits.pension_income_amount
 
-        pension_income_amount = person(
-            "pension_and_savings_plan_income", period
-        )
+        pension_income_amount = person("pension_and_savings_plan_income", period)
 
         return min_(pension_income_amount, p.cap)

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/prc/ns_poverty_reduction_credit.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/credits/prc/ns_poverty_reduction_credit.py
@@ -19,8 +19,6 @@ class ns_poverty_reduction_credit(Variable):
         income_assistance = household("ns_income_assistance", period)
         p = parameters(period).gov.provinces.ns.tax.income.credits.prc
         eligible = (
-            (children == 0)
-            & (income < p.income_threshold)
-            & (income_assistance > 0)
+            (children == 0) & (income < p.income_threshold) & (income_assistance > 0)
         )
         return where(eligible, p.amount, 0)

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/income_assistance/eligibility/assets/ns_income_assistance_applicable_assets.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/income_assistance/eligibility/assets/ns_income_assistance_applicable_assets.py
@@ -7,9 +7,7 @@ class ns_income_assistance_applicable_assets(Variable):
     label = "Nova Scotia income assistance applicable assets"
     unit = CAD
     definition_period = YEAR
-    reference = (
-        "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC2_4"
-    )
+    reference = "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC2_4"
     defined_for = ProvinceCode.NS
 
     adds = "gov.provinces.ns.tax.income.income_assistance.eligibility.assets.applicable_assets"

--- a/policyengine_canada/variables/gov/provinces/ns/tax/income/income_assistance/ns_income_assistance.py
+++ b/policyengine_canada/variables/gov/provinces/ns/tax/income/income_assistance/ns_income_assistance.py
@@ -7,7 +7,5 @@ class ns_income_assistance(Variable):
     label = "Nova Scotia Income Assistance"
     unit = CAD
     definition_period = YEAR
-    reference = (
-        "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC2_4"
-    )
+    reference = "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC2_4"
     defined_for = ProvinceCode.NS

--- a/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_base_component.py
+++ b/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_base_component.py
@@ -10,7 +10,5 @@ class nu_child_benefit_base_component(Variable):
 
     def formula(household, period, parameters):
         base = household("nu_child_benefit_base_component_base", period)
-        reduction = household(
-            "nu_child_benefit_base_component_reduction", period
-        )
+        reduction = household("nu_child_benefit_base_component_reduction", period)
         return max_(0, base - reduction)

--- a/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_base_component_base.py
+++ b/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_base_component_base.py
@@ -11,6 +11,5 @@ class nu_child_benefit_base_component_base(Variable):
     def formula(household, period, parameters):
         children = household("nu_child_benefit_eligible_children", period)
         return (
-            children
-            * parameters(period).gov.provinces.nu.tax.benefits.nucb.base.amount
+            children * parameters(period).gov.provinces.nu.tax.benefits.nucb.base.amount
         )

--- a/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_eligible_child.py
+++ b/policyengine_canada/variables/gov/provinces/nu/tax/income/benefits/nu_child_benefit/nu_child_benefit_eligible_child.py
@@ -10,7 +10,4 @@ class nu_child_benefit_eligible_child(Variable):
 
     def formula(person, period, parameters):
         age = person("age", period)
-        return (
-            age
-            < parameters(period).gov.provinces.nu.tax.benefits.nucb.age_limit
-        )
+        return age < parameters(period).gov.provinces.nu.tax.benefits.nucb.age_limit

--- a/policyengine_canada/variables/gov/provinces/nu/tax/income/credits/nu_cost_of_living_basic_credit.py
+++ b/policyengine_canada/variables/gov/provinces/nu/tax/income/credits/nu_cost_of_living_basic_credit.py
@@ -10,10 +10,6 @@ class nu_cost_of_living_basic_credit(Variable):
     defined_for = ProvinceCode.NU
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.nu.tax.income.credits.cost_of_living
-        adjusted_income = person(
-            "nu_cost_of_living_credit_adjusted_net_income", period
-        )
+        p = parameters(period).gov.provinces.nu.tax.income.credits.cost_of_living
+        adjusted_income = person("nu_cost_of_living_credit_adjusted_net_income", period)
         return min_(p.max_amount, adjusted_income * p.rate)

--- a/policyengine_canada/variables/gov/provinces/nu/tax/income/credits/nu_cost_of_living_credit_supplement.py
+++ b/policyengine_canada/variables/gov/provinces/nu/tax/income/credits/nu_cost_of_living_credit_supplement.py
@@ -13,9 +13,7 @@ class nu_cost_of_living_credit_supplement(Variable):
         p = parameters(
             period
         ).gov.provinces.nu.tax.income.credits.cost_of_living.supplement_for_single_parents
-        adjusted_income = person(
-            "nu_cost_of_living_credit_adjusted_net_income", period
-        )
+        adjusted_income = person("nu_cost_of_living_credit_adjusted_net_income", period)
         excess = max_(0, adjusted_income - p.income)
         uncapped = excess * p.rate
         return min_(uncapped, p.max_amount)

--- a/policyengine_canada/variables/gov/provinces/on/benefits/ocb/on_child_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/on/benefits/ocb/on_child_benefit.py
@@ -18,11 +18,7 @@ class on_child_benefit(Variable):
         shared_custody_divisor = parameters(
             period
         ).gov.provinces.on.benefits.ocb.shared_custody_divisor
-        has_any_full_custody_children = (
-            add(household, period, ["full_custody"]) > 0
-        )
-        divisor = where(
-            has_any_full_custody_children, 1, shared_custody_divisor
-        )
+        has_any_full_custody_children = add(household, period, ["full_custody"]) > 0
+        divisor = where(has_any_full_custody_children, 1, shared_custody_divisor)
         child_benefit_amount = max_(0, base - reduction)
         return child_benefit_amount / divisor

--- a/policyengine_canada/variables/gov/provinces/on/benefits/ocb/on_child_benefit_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/on/benefits/ocb/on_child_benefit_reduction.py
@@ -11,6 +11,4 @@ class on_child_benefit_reduction(Variable):
 
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
-        return parameters(period).gov.provinces.on.benefits.ocb.reduction.calc(
-            income
-        )
+        return parameters(period).gov.provinces.on.benefits.ocb.reduction.calc(income)

--- a/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/is_child_for_on_child_care_fee_subsidy.py
+++ b/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/is_child_for_on_child_care_fee_subsidy.py
@@ -9,7 +9,5 @@ class is_child_for_on_child_care_fee_subsidy(Variable):
 
     def formula(person, period, parameters):
         age = person("age", period)
-        p = parameters(
-            period
-        ).gov.provinces.on.subsidies.on_child_care_fee_subsidy
+        p = parameters(period).gov.provinces.on.subsidies.on_child_care_fee_subsidy
         return age < p.child_age_eligibility

--- a/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy.py
+++ b/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy.py
@@ -12,13 +12,7 @@ class on_child_care_fee_subsidy(Variable):
     def formula(household, period, parameters):
         reduction = household("on_child_care_fee_subsidy_reduction", period)
         full_time = household("full_time_childcare", period)
-        full_time_care = household(
-            "on_child_care_fee_subsidy_full_time", period
-        )
-        part_time_care = household(
-            "on_child_care_fee_subsidy_part_time", period
-        )
-        amount_before_reduction = where(
-            full_time, full_time_care, part_time_care
-        )
+        full_time_care = household("on_child_care_fee_subsidy_full_time", period)
+        part_time_care = household("on_child_care_fee_subsidy_part_time", period)
+        amount_before_reduction = where(full_time, full_time_care, part_time_care)
         return max_(0, amount_before_reduction - reduction)

--- a/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy_full_time.py
+++ b/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy_full_time.py
@@ -10,7 +10,5 @@ class on_child_care_fee_subsidy_full_time(Variable):
 
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.on.subsidies.on_child_care_fee_subsidy
+        p = parameters(period).gov.provinces.on.subsidies.on_child_care_fee_subsidy
         return p.full_time_calculation.calc(income)

--- a/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/on/subsidies/on_child_care_fee_subsidy/on_child_care_fee_subsidy_reduction.py
@@ -20,12 +20,8 @@ class on_child_care_fee_subsidy_reduction(Variable):
         full_factor = where(
             children > 0, eligible_children * reduction_factor / children, 0
         )
-        full_time_reduction = household(
-            "on_child_care_fee_subsidy_full_time", period
-        )
-        part_time_reduction = household(
-            "on_child_care_fee_subsidy_part_time", period
-        )
+        full_time_reduction = household("on_child_care_fee_subsidy_full_time", period)
+        part_time_reduction = household("on_child_care_fee_subsidy_part_time", period)
         eligible = children > 0
         return (
             eligible

--- a/policyengine_canada/variables/gov/provinces/on/tax/grants/oshptg/on_senior_homeowners_property_tax_grant.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/grants/oshptg/on_senior_homeowners_property_tax_grant.py
@@ -11,7 +11,5 @@ class on_senior_homeowners_property_tax_grant(Variable):
 
     def formula(person, period, parameters):
         base = person("on_senior_homeowners_property_tax_grant_base", period)
-        reduction = person(
-            "on_senior_homeowners_property_tax_grant_reduction", period
-        )
+        reduction = person("on_senior_homeowners_property_tax_grant_reduction", period)
         return max_(0, base - reduction)

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/lift/on_low_income_workers_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/lift/on_low_income_workers_tax_credit.py
@@ -13,9 +13,7 @@ class on_low_income_workers_tax_credit(Variable):
         household = person.household
         base = person("on_low_income_workers_tax_credit_base", period)
         afni = household("adjusted_family_net_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.on.tax.income.credits.lift.reduction
+        p = parameters(period).gov.provinces.on.tax.income.credits.lift.reduction
         family = household("is_married", period)
         reduction = where(family, p.family.calc(afni), p.single.calc(afni))
         return max_(base - reduction, 0)

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/lift/on_low_income_workers_tax_credit_eligible_people.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/lift/on_low_income_workers_tax_credit_eligible_people.py
@@ -4,9 +4,7 @@ from policyengine_canada.model_api import *
 class on_low_income_workers_tax_credit_eligible_people(Variable):
     value_type = float
     entity = Person
-    label = (
-        "Sum of eligible people for the Ontario Low-Income Workers Tax Credit"
-    )
+    label = "Sum of eligible people for the Ontario Low-Income Workers Tax Credit"
     unit = CAD
     definition_period = YEAR
 

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/noec/northern_ontario_energy_credit.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/noec/northern_ontario_energy_credit.py
@@ -27,18 +27,13 @@ class northern_ontario_energy_credit(Variable):
             phased_out / p.phase_out.shared_custody.divisor
         )
         # Second phase out process - same steps as previously with different amounts.
-        shared_custody_excess = max_(
-            afni - p.phase_out.shared_custody.start, 0
-        )
-        shared_custody_second_phase_out = (
-            shared_custody_excess * p.phase_out.rate
-        )
+        shared_custody_excess = max_(afni - p.phase_out.shared_custody.start, 0)
+        shared_custody_second_phase_out = shared_custody_excess * p.phase_out.rate
         shared_custody_second_phased_out = (
             p.phase_out.shared_custody.base - shared_custody_second_phase_out
         )
         shared_custody_second_phased_out_divided = (
-            shared_custody_second_phased_out
-            / p.phase_out.shared_custody.divisor
+            shared_custody_second_phased_out / p.phase_out.shared_custody.divisor
         )
         # Single with shared custody household afni under 43_602 amount is 205.50.
         shared_custody_result = where(

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc.py
@@ -18,29 +18,21 @@ class oeptc(Variable):
         afni = household("adjusted_family_net_income", period)
         senior_status = household("oeptc_senior_status", period)
         category = household("oeptc_category", period)
-        p = parameters(
-            period
-        ).gov.provinces.on.tax.income.credits.oeptc.phase_out
+        p = parameters(period).gov.provinces.on.tax.income.credits.oeptc.phase_out
         excess = max_(afni - p.start[senior_status][category], 0)
         phase_out = excess * p.rate
         phased_out = energy_plus_property_tax_components - phase_out
-        shared_custody_phased_out_divided = (
-            phased_out / p.shared_custody.divisor
-        )
-        shared_custody_excess = max_(
-            afni - p.shared_custody.start[senior_status], 0
-        )
+        shared_custody_phased_out_divided = phased_out / p.shared_custody.divisor
+        shared_custody_excess = max_(afni - p.shared_custody.start[senior_status], 0)
         shared_custody_second_phase_out = shared_custody_excess * p.rate
         shared_custody_second_phased_out = (
-            energy_plus_property_tax_components
-            - shared_custody_second_phase_out
+            energy_plus_property_tax_components - shared_custody_second_phase_out
         )
         shared_custody_second_phased_out_divided = (
             shared_custody_second_phased_out / p.shared_custody.divisor
         )
         shared_custody_result = (
-            shared_custody_phased_out_divided
-            + shared_custody_second_phased_out_divided
+            shared_custody_phased_out_divided + shared_custody_second_phased_out_divided
         )
         return max_(
             0,

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_category.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_category.py
@@ -19,9 +19,7 @@ class oeptc_category(Variable):
     def formula(household, period, parameters):
         married = household("is_married", period)
         children = household("oeptc_count_children", period)
-        has_any_full_custody_children = (
-            add(household, period, ["full_custody"]) > 0
-        )
+        has_any_full_custody_children = add(household, period, ["full_custody"]) > 0
         return select(
             [married, children == 0, has_any_full_custody_children],
             [

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_energy_component.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_energy_component.py
@@ -13,14 +13,10 @@ class oeptc_energy_component(Variable):
             period
         ).gov.provinces.on.tax.income.credits.oeptc.energy_component
         long_term_care_home = (
-            household(
-                "rent_paid_to_public_or_non_profit_long_term_care_home", period
-            )
+            household("rent_paid_to_public_or_non_profit_long_term_care_home", period)
             * p.multiplier
         )
-        reserve_home_energy_costs = household(
-            "home_energy_costs_on_a_reserve", period
-        )
+        reserve_home_energy_costs = household("home_energy_costs_on_a_reserve", period)
         student_resident = (
             household("lived_in_a_student_residence", period)
             * p.student_resident_reduction

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_occupancy_cost.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oeptc_occupancy_cost.py
@@ -11,14 +11,8 @@ class oeptc_occupancy_cost(Variable):
     def formula(household, period, parameters):
         person = household.members
         property_tax = person("property_tax", period)
-        p = parameters(
-            period
-        ).gov.provinces.on.tax.income.credits.oeptc.occupancy_costs
+        p = parameters(period).gov.provinces.on.tax.income.credits.oeptc.occupancy_costs
         student_residence = household("lived_in_a_student_residence", period)
         countable_rent = person("rent", period) * p.rent_multiplier
-        student_residence_addition = (
-            student_residence * p.student_resident_supplement
-        )
-        return household.sum(
-            countable_rent + property_tax + student_residence_addition
-        )
+        student_residence_addition = student_residence * p.student_resident_supplement
+        return household.sum(countable_rent + property_tax + student_residence_addition)

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oshptg_adjusted_oeptc.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/oeptc/oshptg_adjusted_oeptc.py
@@ -18,7 +18,5 @@ class oshptg_adjusted_oeptc(Variable):
         energy_component = household("oeptc_energy_component", period)
         adjusted_for_energy_component = adjusted_oeptc - energy_component
         occupany_costs = household("oeptc_occupancy_cost", period)
-        adjusted_for_occupany_costs = (
-            adjusted_for_energy_component - occupany_costs
-        )
+        adjusted_for_occupany_costs = adjusted_for_energy_component - occupany_costs
         return max_(eligible * (oeptc - adjusted_for_occupany_costs), 0)

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/ostc/on_sales_tax_credit_base.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/ostc/on_sales_tax_credit_base.py
@@ -6,9 +6,7 @@ class on_sales_tax_credit_base(Variable):
     entity = Household
     label = "Ontario Sales Tax Credit Base"
     unit = CAD
-    documentation = (
-        "Base amount of Ontario sales tax credits before reduction."
-    )
+    documentation = "Base amount of Ontario sales tax credits before reduction."
     definition_period = YEAR
     defined_for = ProvinceCode.ONT
 

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/credits/ostc/on_sales_tax_credit_reduction.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/credits/ostc/on_sales_tax_credit_reduction.py
@@ -11,7 +11,5 @@ class on_sales_tax_credit_reduction(Variable):
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
         family = household("household_size", period) > 1
-        p = parameters(
-            period
-        ).gov.provinces.on.tax.income.credits.ostc.reduction
+        p = parameters(period).gov.provinces.on.tax.income.credits.ostc.reduction
         return where(family, p.family.calc(income), p.single.calc(income))

--- a/policyengine_canada/variables/gov/provinces/on/tax/income/on_income_tax_before_refundable_credits.py
+++ b/policyengine_canada/variables/gov/provinces/on/tax/income/on_income_tax_before_refundable_credits.py
@@ -10,10 +10,6 @@ class on_income_tax_before_refundable_credits(Variable):
     reference = "https://www.canada.ca/en/revenue-agency/services/tax/individuals/frequently-asked-questions-individuals/canadian-income-tax-rates-individuals-current-previous-years.html"
 
     def formula(person, period, parameters):
-        income_tax_before_credits = person(
-            "on_income_tax_before_credits", period
-        )
-        non_refundable_tax_credits = person(
-            "on_non_refundable_credits", period
-        )
+        income_tax_before_credits = person("on_income_tax_before_credits", period)
+        non_refundable_tax_credits = person("on_non_refundable_credits", period)
         return max_(income_tax_before_credits - non_refundable_tax_credits, 0)

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/cce/qc_cce_disabled_child_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/cce/qc_cce_disabled_child_tax_credit.py
@@ -28,10 +28,6 @@ class qc_cce_disabled_child_tax_credit(Variable):
         )
         eligible = disabled & (own_child | qualifying_non_own_child_dependant)
 
-        credit = (
-            credit_rate
-            * eligible
-            * min_(p.disabled_child_expense_limit, expense)
-        )
+        credit = credit_rate * eligible * min_(p.disabled_child_expense_limit, expense)
 
         return household.sum(credit)

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/cost_of_living/qc_cost_of_living_credit.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/cost_of_living/qc_cost_of_living_credit.py
@@ -9,9 +9,7 @@ class qc_cost_of_living_credit(Variable):
     defined_for = ProvinceCode.QC
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.qc.tax.income.credits.cost_of_living
+        p = parameters(period).gov.provinces.qc.tax.income.credits.cost_of_living
         income = person("individual_net_income", period)
 
         # determine eligibility:

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_exceptional_care_tier1_child.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_exceptional_care_tier1_child.py
@@ -4,7 +4,9 @@ from policyengine_canada.model_api import *
 class qc_fa_exceptional_care_tier1(Variable):
     value_type = bool
     entity = Person
-    label = "Quebec family allowance handicapped children requiring Tier 1 exceptional care"
+    label = (
+        "Quebec family allowance handicapped children requiring Tier 1 exceptional care"
+    )
     reference = "https://www.rrq.gouv.qc.ca/en/enfants/enfant_handicape/seh-necessitant-soins-exceptionnels/Pages/seh-necessitant-soins-exceptionnels.aspx"
     definition_period = YEAR
     defined_for = ProvinceCode.QC

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_exceptional_care_tier2.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_exceptional_care_tier2.py
@@ -4,7 +4,9 @@ from policyengine_canada.model_api import *
 class qc_fa_exceptional_care_tier2(Variable):
     value_type = bool
     entity = Person
-    label = "Quebec family allowance handicapped children requiring Tier 2 exceptional care"
+    label = (
+        "Quebec family allowance handicapped children requiring Tier 2 exceptional care"
+    )
     reference = "https://www.rrq.gouv.qc.ca/en/enfants/enfant_handicape/seh-necessitant-soins-exceptionnels/Pages/seh-necessitant-soins-exceptionnels.aspx"
     definition_period = YEAR
     defined_for = ProvinceCode.QC

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_payment.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_payment.py
@@ -21,9 +21,7 @@ class qc_fa_payment(Variable):
 
         # check if each child is full custody
         full_custody = person("full_custody", period)
-        shared_custody_multiplier = where(
-            full_custody, 1, p.shared_custody_multiplier
-        )
+        shared_custody_multiplier = where(full_custody, 1, p.shared_custody_multiplier)
 
         # method 1: calculate using max amount with reduction threshold
         # (C + D) − 4% (E − F) in taxation axt
@@ -31,9 +29,7 @@ class qc_fa_payment(Variable):
             age_eligible * p.child_amount.max * shared_custody_multiplier
         )
 
-        single_parent_max_amount = where(
-            has_spouse, 0, p.single_parent_amount.max
-        )
+        single_parent_max_amount = where(has_spouse, 0, p.single_parent_amount.max)
 
         income = household("adjusted_family_net_income", period)
         reduction = where(
@@ -41,17 +37,13 @@ class qc_fa_payment(Variable):
             p.reduction.two_parent_family.calc(income),
             p.reduction.single_parent_family.calc(income),
         )
-        max_credit_amount = (
-            maximum_child_amount + single_parent_max_amount - reduction
-        )
+        max_credit_amount = maximum_child_amount + single_parent_max_amount - reduction
 
         # method 2: calculate using min amounts, G+H in taxation axt
         minimum_child_amount = household.sum(
             age_eligible * p.child_amount.min * shared_custody_multiplier
         )
-        single_parent_min_amount = where(
-            has_spouse, 0, p.single_parent_amount.min
-        )
+        single_parent_min_amount = where(has_spouse, 0, p.single_parent_amount.min)
 
         min_credit_amount = minimum_child_amount + single_parent_min_amount
 

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_supplement.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/fa/qc_fa_supplement.py
@@ -16,9 +16,7 @@ class qc_fa_supplement(Variable):
 
         # check if the child is full custody of the head
         full_custody = person("full_custody", period)
-        shared_custody_multiplier = where(
-            full_custody, 1, p.shared_custody_multiplier
-        )
+        shared_custody_multiplier = where(full_custody, 1, p.shared_custody_multiplier)
 
         # Supplement for Handicapped Children
         handicapped = person("is_disabled", period)

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/sa/qc_sa_married_one_eligible.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/sa/qc_sa_married_one_eligible.py
@@ -4,7 +4,9 @@ from policyengine_canada.model_api import *
 class qc_sa_married_one_eligible(Variable):
     value_type = int
     entity = Household
-    label = "Quebec senior assistance tax credits for family with only one eligible senior"
+    label = (
+        "Quebec senior assistance tax credits for family with only one eligible senior"
+    )
     definition_period = YEAR
     defined_for = ProvinceCode.QC
 

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/sa/qc_sa_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/sa/qc_sa_tax_credit.py
@@ -14,9 +14,7 @@ class qc_sa_tax_credit(Variable):
         income = household("adjusted_family_net_income", period)
 
         # Your spouse is an eligible individual and you were both 70 or over
-        married_both_eligible = household(
-            "qc_sa_married_both_eligible", period
-        )
+        married_both_eligible = household("qc_sa_married_both_eligible", period)
         credit_married_both_eligible = married_both_eligible * max_(
             0,
             p.amount.married_both_eligible - p.reduction.married.calc(income),
@@ -35,7 +33,5 @@ class qc_sa_tax_credit(Variable):
         )
 
         return (
-            credit_married_both_eligible
-            + credit_married_one_eligible
-            + credit_single
+            credit_married_both_eligible + credit_married_one_eligible + credit_single
         )

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/adapted_work_premium/qc_adapted_work_premium_eligible.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/adapted_work_premium/qc_adapted_work_premium_eligible.py
@@ -24,6 +24,4 @@ class qc_adapted_work_premium_eligible(Variable):
             person("working_income", period) > p.work_income_requirement
         )
 
-        return household.any(
-            is_head_or_spouse & disabled & work_income_eligible
-        )
+        return household.any(is_head_or_spouse & disabled & work_income_eligible)

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/qc_work_premium_credit_base.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/qc_work_premium_credit_base.py
@@ -18,6 +18,4 @@ class qc_work_premium_credit_base(Variable):
 
         # If you are entitled to both the work premium and the adapted work premium
         # you will receive the greater of the two
-        return max_(
-            qc_general_work_premium_amount, qc_adapted_work_premium_amount
-        )
+        return max_(qc_general_work_premium_amount, qc_adapted_work_premium_amount)

--- a/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/qc_work_premium_credit_supplement.py
+++ b/policyengine_canada/variables/gov/provinces/qc/tax/income/credits/work_premium/qc_work_premium_credit_supplement.py
@@ -18,9 +18,7 @@ class qc_work_premium_credit_supplement(Variable):
         work_income_eligible = (
             person("working_income", period) > p.work_income_eligibility
         )
-        supplement_eligible = household.sum(
-            work_income_eligible & is_head_or_spouse
-        )
+        supplement_eligible = household.sum(work_income_eligible & is_head_or_spouse)
 
         return select(
             [supplement_eligible == 2, supplement_eligible == 1],

--- a/policyengine_canada/variables/gov/provinces/sk/benefits/afb/sk_active_family_benefit.py
+++ b/policyengine_canada/variables/gov/provinces/sk/benefits/afb/sk_active_family_benefit.py
@@ -18,7 +18,7 @@ class sk_active_family_benefit(Variable):
         disabled_children = household.sum(child & disabled)
         non_disabled_children = children - disabled_children
         eligible = income <= p.eligibility.income
-        amount_if_eligible = (
-            p.amount.non_disabled * non_disabled_children
-        ) + (p.amount.disabled * disabled_children)
+        amount_if_eligible = (p.amount.non_disabled * non_disabled_children) + (
+            p.amount.disabled * disabled_children
+        )
         return eligible * amount_if_eligible

--- a/policyengine_canada/variables/gov/provinces/sk/tax/income/credits/disability_amount/sk_disability_amount.py
+++ b/policyengine_canada/variables/gov/provinces/sk/tax/income/credits/disability_amount/sk_disability_amount.py
@@ -10,8 +10,6 @@ class sk_disability_amount(Variable):
     defined_for = ProvinceCode.SK
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.sk.tax.income.credits.disability_amount
+        p = parameters(period).gov.provinces.sk.tax.income.credits.disability_amount
         disabled = person("is_disabled", period)
         return disabled * p.amount

--- a/policyengine_canada/variables/gov/provinces/yt/benefits/yukon_child_benefit/yt_child_benefit_base.py
+++ b/policyengine_canada/variables/gov/provinces/yt/benefits/yukon_child_benefit/yt_child_benefit_base.py
@@ -11,6 +11,5 @@ class yt_child_benefit_base(Variable):
     def formula(household, period, parameters):
         children = household("yt_child_benefit_eligible_children", period)
         return (
-            children
-            * parameters(period).gov.provinces.yt.benefits.child_benefit.base
+            children * parameters(period).gov.provinces.yt.benefits.child_benefit.base
         )

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/benefits/rebates/ygcpri/yt_government_carbon_price_rebate.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/benefits/rebates/ygcpri/yt_government_carbon_price_rebate.py
@@ -23,9 +23,5 @@ class yt_government_carbon_price_rebate(Variable):
             + (p.non_whitehorse_supplement.spouse * spouses)
             + p.non_whitehorse_supplement.self
         )
-        base = (
-            (p.amount.child * children)
-            + (p.amount.spouse * spouses)
-            + p.amount.self
-        )
+        base = (p.amount.child * children) + (p.amount.spouse * spouses) + p.amount.self
         return base + non_whitehorse_supplement

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_arts_credit/yt_childrens_arts_credit.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_arts_credit/yt_childrens_arts_credit.py
@@ -9,11 +9,7 @@ class yt_childrens_arts_credit(Variable):
     defined_for = ProvinceCode.YT
 
     def formula(household, period, parameters):
-        children = household(
-            "yt_childrens_arts_credit_eligible_children", period
-        )
+        children = household("yt_childrens_arts_credit_eligible_children", period)
         expenses = household("yt_childrens_arts_credit_expenses", period)
-        p = parameters(
-            period
-        ).gov.provinces.yt.tax.income.credits.childrens_arts_credit
+        p = parameters(period).gov.provinces.yt.tax.income.credits.childrens_arts_credit
         return min_(expenses, children * p.amount)

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_fitness_tax_credit/yt_cftc_eligible_child.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_fitness_tax_credit/yt_cftc_eligible_child.py
@@ -10,10 +10,6 @@ class yt_cftc_eligible_child(Variable):
 
     def formula(person, period, parameters):
         age = person("age", period)
-        p = parameters(
-            period
-        ).gov.provinces.yt.tax.income.credits.childrens_fitness
-        disabled = person("is_disabled", period) & (
-            age < p.disability_supplement.age
-        )
+        p = parameters(period).gov.provinces.yt.tax.income.credits.childrens_fitness
+        disabled = person("is_disabled", period) & (age < p.disability_supplement.age)
         return disabled | (age < p.child_age_eligibility)

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_fitness_tax_credit/yt_childrens_fitness_tax_credit.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/childrens_fitness_tax_credit/yt_childrens_fitness_tax_credit.py
@@ -16,9 +16,7 @@ class yt_childrens_fitness_tax_credit(Variable):
         disability_supplement = household(
             "yt_childrens_fitness_tax_credit_disability_supplement", period
         )
-        p = parameters(
-            period
-        ).gov.provinces.yt.tax.income.credits.childrens_fitness
+        p = parameters(period).gov.provinces.yt.tax.income.credits.childrens_fitness
         # maximum of $ 1,000 per child tof eligible fees can be multiplied by
         # the refundable rate of % 6.4
         maximum_fees = total_children * p.base

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_basic_personal_amount_additional.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_basic_personal_amount_additional.py
@@ -14,9 +14,7 @@ class yt_additional_basic_personal_amount(Variable):
         ).gov.provinces.yt.tax.income.credits.basic_personal_amount.additional
 
         individual_net_income = person("individual_net_income", period)
-        additional_amount = p.divisor - (
-            individual_net_income - p.income_threshold
-        )
+        additional_amount = p.divisor - (individual_net_income - p.income_threshold)
         additional_amount_eligible = additional_amount > 0
         yt_additional_amount = additional_amount_eligible * additional_amount
         yt_additional_amount = yt_additional_amount / p.divisor

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_basic_personal_amount_base.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_basic_personal_amount_base.py
@@ -7,6 +7,4 @@ class yt_basic_personal_amount_base(Variable):
     label = "Yukon basic personal amount base"
     definition_period = YEAR
     defined_for = ProvinceCode.YT
-    adds = (
-        "gov.provinces.yt.tax.income.credits.basic_personal_amount.base_amount"
-    )
+    adds = "gov.provinces.yt.tax.income.credits.basic_personal_amount.base_amount"

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_employment_amount.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_employment_amount.py
@@ -11,8 +11,6 @@ class yt_employment_amount(Variable):
     reference = "https://www.canada.ca/en/revenue-agency/services/forms-publications/tax-packages-years/general-income-tax-benefit-package/yukon/5011-pc/information-residents-yukon.html#P4_58310"
 
     def formula(person, period, parameters):
-        p = parameters(
-            period
-        ).gov.provinces.yt.tax.income.credits.employment_amount
+        p = parameters(period).gov.provinces.yt.tax.income.credits.employment_amount
         canada_employment_amount = person("canada_employment_amount", period)
         return min_(canada_employment_amount, p.amount)

--- a/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_first_nations_tax.py
+++ b/policyengine_canada/variables/gov/provinces/yt/tax/income/credits/yt_first_nations_tax.py
@@ -10,8 +10,6 @@ class yt_first_nations_tax(Variable):
 
     def formula(household, period, parameters):
         income = household("adjusted_family_net_income", period)
-        p = parameters(
-            period
-        ).gov.provinces.yt.tax.income.credits.first_nations_tax
+        p = parameters(period).gov.provinces.yt.tax.income.credits.first_nations_tax
         eligible = household("resides_on_settlement_land", period)
         return income * p.rate * eligible

--- a/policyengine_canada/variables/household/demographic/geographic/province/province_code.py
+++ b/policyengine_canada/variables/household/demographic/geographic/province/province_code.py
@@ -28,6 +28,4 @@ class province_code(Variable):
     definition_period = ETERNITY
 
     def formula(household, period, parameters):
-        return ProvinceCode.encode(
-            household("province_name", period).decode_to_str()
-        )
+        return ProvinceCode.encode(household("province_name", period).decode_to_str())

--- a/policyengine_canada/variables/household/income/individual/investment_income.py
+++ b/policyengine_canada/variables/household/income/individual/investment_income.py
@@ -6,8 +6,6 @@ class investment_income(Variable):
     entity = Person
     label = "Investment income"
     unit = CAD
-    documentation = (
-        "Income from investments including dividends and capital gains"
-    )
+    documentation = "Income from investments including dividends and capital gains"
     definition_period = YEAR
     reference = "https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-income/self-employment-income-lines-13499-14299-gross-income-lines-13500-14300-net-income.html"

--- a/policyengine_canada/variables/household/income/individual/other_employment_income.py
+++ b/policyengine_canada/variables/household/income/individual/other_employment_income.py
@@ -6,6 +6,8 @@ class other_employment_income(Variable):
     entity = Person
     label = "Other employment income"
     unit = CAD
-    documentation = "Employment income reported on Line 10400 of the personal income tax return"
+    documentation = (
+        "Employment income reported on Line 10400 of the personal income tax return"
+    )
     definition_period = YEAR
     reference = "https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-income/line-10400-other-employment-income.html"

--- a/policyengine_canada/variables/household/marginal_tax_rate.py
+++ b/policyengine_canada/variables/household/marginal_tax_rate.py
@@ -3,7 +3,9 @@ from policyengine_canada.model_api import *
 
 class marginal_tax_rate(Variable):
     label = "marginal tax rate"
-    documentation = "Percent of marginal income gains that do not increase household net income."
+    documentation = (
+        "Percent of marginal income gains that do not increase household net income."
+    )
     entity = Person
     definition_period = YEAR
     value_type = float
@@ -14,13 +16,9 @@ class marginal_tax_rate(Variable):
         simulation = person.simulation
         adult_index_values = person("adult_index", period)
         DELTA = 1_000
-        mtr_adult_count = parameters(
-            period
-        ).simulation.marginal_tax_rate_adults
+        mtr_adult_count = parameters(period).simulation.marginal_tax_rate_adults
         for adult_index in range(1, 1 + mtr_adult_count):
-            alt_simulation = simulation.get_branch(
-                f"adult_{adult_index}_pay_rise"
-            )
+            alt_simulation = simulation.get_branch(f"adult_{adult_index}_pay_rise")
             mask = adult_index_values == adult_index
             for variable in simulation.tax_benefit_system.variables:
                 if variable not in simulation.input_variables:
@@ -31,15 +29,11 @@ class marginal_tax_rate(Variable):
                 person("employment_income", period) + mask * DELTA,
             )
             alt_person = alt_simulation.person
-            household_net_income = person.household(
-                "household_net_income", period
-            )
+            household_net_income = person.household("household_net_income", period)
             household_net_income_higher_earnings = alt_person.household(
                 "household_net_income", period
             )
-            increase = (
-                household_net_income_higher_earnings - household_net_income
-            )
+            increase = household_net_income_higher_earnings - household_net_income
             mtr_values += where(mask, 1 - increase / DELTA, 0)
         return mtr_values
 

--- a/policyengine_canada/variables/household/person/in_need_of_protective_services.py
+++ b/policyengine_canada/variables/household/person/in_need_of_protective_services.py
@@ -6,6 +6,4 @@ class in_need_of_protective_services(Variable):
     entity = Person
     label = "Person is in need of protective services"
     definition_period = YEAR
-    reference = (
-        "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC3_8"
-    )
+    reference = "https://novascotia.ca/just/regulations/regs/esiaregs.htm#TOC3_8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 dependencies = [
-    "black[jupyter]",
     "coverage<7",
     "dpath<3",
     "h5py>=3,<4",
-    "linecheck<1",
+    "ruff>=0.9.0",
     "microdf_python>=1.2.1",
     "nptyping<2",
     "numexpr<3",
@@ -92,3 +91,6 @@ showcontent = true
 directory = "removed"
 name = "Removed"
 showcontent = true
+
+[tool.ruff]
+line-length = 88


### PR DESCRIPTION
## Summary
- Remove `black[jupyter]` and `linecheck` dependencies from `pyproject.toml`, add `ruff>=0.9.0`
- Update Makefile `format` target to use `ruff format .`
- Replace `lgeiger/black-action` in CI workflows (pr.yaml, push.yaml) with `ruff format --check .`
- Add `[tool.ruff] line-length = 88` config to `pyproject.toml`
- Reformat all Python files with ruff (106 files reformatted)
- Add towncrier changelog fragment

## Test plan
- [x] `ruff format --check .` passes locally
- [ ] CI Lint job passes with new ruff check
- [ ] `make format` works correctly with ruff

Generated with [Claude Code](https://claude.com/claude-code)