### PR TITLE
Mint GitHub App token in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -26,10 +26,16 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine Canada')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -49,6 +55,8 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine Canada
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false
   Test:
     runs-on: ${{ matrix.os }}
     if: |
@@ -111,13 +119,17 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-canada')
       && (github.event.head_commit.message == 'Update PolicyEngine Canada')
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -130,4 +142,4 @@ jobs:
       - name: Update API
         run: python .github/update_api.py
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/fixed/migrate-to-app-token.md
+++ b/changelog.d/fixed/migrate-to-app-token.md
@@ -1,0 +1,1 @@
+Migrated push workflow from the expired `POLICYENGINE_GITHUB` PAT to a short-lived GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`), so the `versioning` job can push the "Update PolicyEngine Canada" commit that triggers Test, Publish, and Deploy. Matches the pattern already used by policyengine-core, policyengine-us, and microdf.


### PR DESCRIPTION
## Summary
- Replace the expired `POLICYENGINE_GITHUB` PAT with a short-lived GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`) in the `versioning` and `Deploy` jobs of `.github/workflows/push.yaml`.
- Each job generates its own `app-token` step since GitHub App tokens do not cross job boundaries.
- Update `EndBug/add-and-commit@v9` to pass `github_token: steps.app-token.outputs.token` and `fetch: false`.
- Replace `GH_TOKEN` env and the `update_api.py` cross-repo `GITHUB_TOKEN` with the app token output.
- Add a towncrier fragment under `changelog.d/fixed/`.

Matches the pattern already used by `policyengine-core` (PR #470), `policyengine-us` (PR #7807), and `microdf` (PR #296).

## Test plan
- [ ] CI green on this PR (Lint)
- [ ] Next commit to master that is not "Update PolicyEngine Canada" triggers the `versioning` job, which successfully pushes the auto-bump commit and kicks off Test / Publish / Deploy